### PR TITLE
Added Enum Class for Flow Control

### DIFF
--- a/include/CppLinuxSerial/SerialPort.hpp
+++ b/include/CppLinuxSerial/SerialPort.hpp
@@ -81,6 +81,13 @@ namespace mn {
             TWO,
         };
 
+        /// \brief      Adding the ability to choose a flow control strategy on instantiation
+        enum class FlowControl {
+            NONE,
+            HARDWARE,
+            SOFTWARE,
+        };
+
         /// \brief      Represents the state of the serial port.
         enum class State {
             CLOSED,
@@ -99,6 +106,9 @@ namespace mn {
 
             /// \brief		Constructor that sets up serial port and allows the user to specify all the common parameters.
             SerialPort(const std::string &device, BaudRate baudRate, NumDataBits numDataBits, Parity parity, NumStopBits numStopBits);
+
+            /// \brief		Constructor that sets up serial port and allows the user to specify all the common parameters + Flow control.
+            SerialPort(const std::string &device, BaudRate baudRate, NumDataBits numDataBits, Parity parity, NumStopBits numStopBits, FlowControl flow);
 
             /// \brief		Constructor that sets up serial port with the basic parameters, and a custom baud rate.
             SerialPort(const std::string &device, speed_t baudRate);
@@ -211,6 +221,8 @@ namespace mn {
             /// \brief      The num. of stop bits. Defaults to 1 (most common).
             NumStopBits numStopBits_ = NumStopBits::ONE;
 
+            /// \brief      The flow control of the system. Defaults to None (most common).
+            FlowControl flowControl_ = FlowControl::NONE;
             /// \brief		The file descriptor for the open file. This gets written to when Open() is called.
             int fileDesc_;
 

--- a/include/CppLinuxSerial/SerialPort.hpp
+++ b/include/CppLinuxSerial/SerialPort.hpp
@@ -173,6 +173,10 @@ namespace mn {
             /// \throws		CppLinuxSerial::Exception if state != OPEN.
             int32_t Available();
 
+            /// \brief          Use to get the state of the serial port
+            /// \returns        The state of the serial port
+            State getState();
+
         private:
 
             /// \brief		Configures the tty device as a serial port.

--- a/include/CppLinuxSerial/SerialPort.hpp
+++ b/include/CppLinuxSerial/SerialPort.hpp
@@ -175,7 +175,7 @@ namespace mn {
 
             /// \brief          Use to get the state of the serial port
             /// \returns        The state of the serial port
-            State getState();
+            State GetState();
 
         private:
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -638,7 +638,7 @@ namespace CppLinuxSerial {
         return ret;
         
     }
-    State SerialPort::getState() {
+    State SerialPort::GetState() {
       return state_;
     }
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -638,6 +638,9 @@ namespace CppLinuxSerial {
         return ret;
         
     }
+    State SerialPort::getState() {
+      return state_;
+    }
 
 } // namespace CppLinuxSerial
 } // namespace mn

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -68,6 +68,17 @@ namespace CppLinuxSerial {
 		numStopBits_ = numStopBits;
 	}
 
+	SerialPort::SerialPort(const std::string &device, BaudRate baudRate, NumDataBits numDataBits, Parity parity, NumStopBits numStopBits, FlowControl flow):
+            SerialPort() {
+		device_ = device;
+		baudRateType_ = BaudRateType::STANDARD;
+        baudRateStandard_ = baudRate;
+		numDataBits_ = numDataBits;
+		parity_ = parity;
+		numStopBits_ = numStopBits;
+		flowControl_ = flow;
+	}
+
 	SerialPort::~SerialPort() {
         try {
             Close();
@@ -209,7 +220,22 @@ namespace CppLinuxSerial {
 				THROW_EXCEPT("numStopBits_ value not supported!");
 		}
 
-		tty.c_cflag     &=  ~CRTSCTS;       // Disable hadrware flow control (RTS/CTS)
+		switch(flowControl_){
+			case FlowControl::NONE:
+				tty.c_cflag     &=  ~CRTSCTS;	
+			break;
+
+			case FlowControl::HARDWARE:
+				tty.c_cflag		|= CRTSCTS;
+			break;
+
+			default:
+				THROW_EXCEPT("flowControl_ value not supported!");
+			break;
+		}
+		       // Disable hardware flow control (RTS/CTS)
+		
+		
 		tty.c_cflag     |=  CREAD | CLOCAL;     				// Turn on READ & ignore ctrl lines (CLOCAL = 1)
 
 
@@ -414,7 +440,16 @@ namespace CppLinuxSerial {
 
 		//======================== (.c_iflag) ====================//
 
-		tty.c_iflag     &= ~(IXON | IXOFF | IXANY);			// Turn off s/w flow ctrl
+		switch(flowControl_){
+			case FlowControl::NONE:
+				tty.c_iflag     &= ~(IXON | IXOFF | IXANY);
+			break;
+
+			case FlowControl::SOFTWARE:
+				tty.c_iflag     |= (IXON | IXOFF | IXANY);
+			break;
+		}
+					// Turn off s/w flow ctrl
 		tty.c_iflag 	&= ~(IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL);
 
 		//=========================== LOCAL MODES (c_lflag) =======================//


### PR DESCRIPTION
A sensor I am using requires flow control on, but the rest of the system does not.

Therefore I implemented an overloaded constructor and enum class to set it as required.

I tried my best to follow the format of the code as it already was, please forgive any lack of form.

Still new to pull requests and proper practices.