### PR TITLE
Added getState

### DIFF
--- a/include/CppLinuxSerial/SerialPort.hpp
+++ b/include/CppLinuxSerial/SerialPort.hpp
@@ -173,6 +173,10 @@ namespace mn {
             /// \throws		CppLinuxSerial::Exception if state != OPEN.
             int32_t Available();
 
+            /// \brief          Use to get the state of the serial port
+            /// \returns        The state of the serial port
+            State getState();
+
         private:
 
             /// \brief		Configures the tty device as a serial port.

--- a/include/CppLinuxSerial/SerialPort.hpp
+++ b/include/CppLinuxSerial/SerialPort.hpp
@@ -175,7 +175,7 @@ namespace mn {
 
             /// \brief          Use to get the state of the serial port
             /// \returns        The state of the serial port
-            State getState();
+            State GetState();
 
         private:
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -638,7 +638,7 @@ namespace CppLinuxSerial {
         return ret;
         
     }
-    State SerialPort::getState() {
+    State SerialPort::GetState() {
       return state_;
     }
 

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -638,6 +638,9 @@ namespace CppLinuxSerial {
         return ret;
         
     }
+    State SerialPort::getState() {
+      return state_;
+    }
 
 } // namespace CppLinuxSerial
 } // namespace mn


### PR DESCRIPTION
I did not see any options to get the state (open/closed) of the serial port, so I added a function to read the state