### PR TITLE
Throw exception on device disconnection

### DIFF
--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -533,6 +533,17 @@ namespace CppLinuxSerial {
         // is called
         ssize_t n = read(fileDesc_, &readBuffer_[0], readBufferSize_B_);
 
+        if(n == 0)
+        {
+            struct termios2 term2;
+            int rv = ioctl(fileDesc_, TCGETS2, &term2);
+
+            if(rv != 0)
+            {
+                throw std::system_error(EFAULT, std::system_category());
+            }
+        }
+
         // Error Handling
         if(n < 0) {
             // Read was unsuccessful

--- a/src/SerialPort.cpp
+++ b/src/SerialPort.cpp
@@ -533,25 +533,22 @@ namespace CppLinuxSerial {
         // is called
         ssize_t n = read(fileDesc_, &readBuffer_[0], readBufferSize_B_);
 
-        if(n == 0)
-        {
-            struct termios2 term2;
-            int rv = ioctl(fileDesc_, TCGETS2, &term2);
-
-            if(rv != 0)
-            {
-                throw std::system_error(EFAULT, std::system_category());
-            }
-        }
-
         // Error Handling
         if(n < 0) {
             // Read was unsuccessful
             throw std::system_error(EFAULT, std::system_category());
         }
-
-        if(n > 0) {
+        else if(n > 0) {
             data = std::string(&readBuffer_[0], n);
+        }
+        else if(n == 0) {
+            // n == 0 means EOS, but also returned on device disconnection. We try to get termios2 to distinguish two these two states
+            struct termios2 term2;
+            int rv = ioctl(fileDesc_, TCGETS2, &term2);
+
+            if(rv != 0) {
+                throw std::system_error(EFAULT, std::system_category());
+            }
         }
 
         // If code reaches here, read must of been successful


### PR DESCRIPTION
Hi @gbmhunter ! Here is PR to solve issue described in #32 
The problem is that there are no way to distinguish between read timeout and device disconnection. My fix uses ioctl's return value to conclude what exactly happened.
Works reliably on my machine under Ubuntu 18.04 on USB-Serial device.