### PR TITLE
Added Cmake exporting for easier consumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.1.0)
-project(CppLinuxSerial)
-
-add_definitions(-std=c++14)
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
+project(CppLinuxSerial VERSION 2.7.0)
 
 option(BUILD_TESTS "If set to true, unit tests will be build as part of make all." TRUE)
 if (BUILD_TESTS)
@@ -55,10 +50,6 @@ endif()
 #=================================================================================================#
 #========================================= This Project ==========================================#
 #=================================================================================================#
-
-# Now simply link your own targets against gtest, gmock,
-# etc. as appropriate
-include_directories(include)
 
 add_subdirectory(src)
 if(BUILD_TESTS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,29 +1,63 @@
 
-
-file(GLOB_RECURSE CppLinuxSerial_SRC
-        "*.cpp")
-
-file(GLOB_RECURSE CppLinuxSerial_HEADERS
-        "${CMAKE_SOURCE_DIR}/include/*.hpp")
-
 option(SERIAL_BUILD_SHARED_LIBS "Build CppLinuxSerial shared library" OFF)
 
 if (SERIAL_BUILD_SHARED_LIBS)
-  set(LibType SHARED)
+  add_library(CppLinuxSerial SHARED)
 else()
-  set(LibType STATIC)
+  add_library(CppLinuxSerial STATIC)
 endif()
 
-add_library(CppLinuxSerial ${LibType} ${CppLinuxSerial_SRC} ${CppLinuxSerial_HEADERS})
+add_library(CppLinuxSerial::CppLinuxSerial ALIAS CppLinuxSerial)
 
+target_compile_features(CppLinuxSerial PRIVATE cxx_std_14)
 
-target_include_directories(CppLinuxSerial PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
-                                                "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>")                                                  
+target_sources(CppLinuxSerial
+  PRIVATE 
+    SerialPort.cpp)
 
-# On Linux, "sudo make install" will typically copy the library
-# into the folder /usr/local/bin
-install(TARGETS CppLinuxSerial DESTINATION lib)
+target_include_directories(
+  CppLinuxSerial 
+    PUBLIC 
+      "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>"
+      "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>"
+)
 
-# On Linux, "sudo make install" will typically copy the
-# folder into /usr/local/include
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/CppLinuxSerial DESTINATION include)
+## Installing
+include(CMakePackageConfigHelpers)
+
+install(
+  TARGETS CppLinuxSerial 
+  EXPORT CppLinuxSerialTargets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  INCLUDES DESTINATION include
+)
+
+install(
+  EXPORT CppLinuxSerialTargets
+  FILE CppLinuxSerialTargets.cmake
+  NAMESPACE CppLinuxSerial::
+  DESTINATION lib/cmake/CppLinuxSerial
+)
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../include/CppLinuxSerial 
+  DESTINATION include
+)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/CppLinuxSerialConfig.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/CppLinuxSerial
+)
+
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    CppLinuxSerialConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+
+install(
+  FILES 
+    "${CMAKE_CURRENT_BINARY_DIR}/CppLinuxSerialConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/CppLinuxSerialConfigVersion.cmake"
+  DESTINATION lib/cmake/CppLinuxSerial
+)

--- a/src/Config.cmake.in
+++ b/src/Config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/CppLinuxSerialTargets.cmake")
+
+check_required_components(CppLinuxSerial)


### PR DESCRIPTION
This PR adds cmake exporting and generates a cmake config file. This is required for downstream projects to consume the project using find_package() without requiring the downstream to author a FindPackage.

This is my main reference when packaging my cmake projects:
https://cliutils.gitlab.io/modern-cmake/chapters/install/installing.html
