### PR TITLE
fix bug to download and build gtest also when being a cmake subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,13 +18,13 @@ if (BUILD_TESTS)
     configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
     execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
             RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
     if(result)
         message(FATAL_ERROR "CMake step for googletest failed: ${result}")
     endif()
     execute_process(COMMAND ${CMAKE_COMMAND} --build .
             RESULT_VARIABLE result
-            WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
     if(result)
         message(FATAL_ERROR "Build step for googletest failed: ${result}")
     endif()


### PR DESCRIPTION
I included this repo as a git submodule in my project and included it via the `add_subdirectory(lib/CppLinuxSerial)` command in my top-level `CMakeLists.txt` to the build environment.

Right now the build then fails with the message:
```
CMake Error at lib/CppLinuxSerial/CMakeLists.txt:23 (message):
  CMake step for googletest failed: No such file or directory
```

With this pull request this error is resolved and the build succeeds. 